### PR TITLE
Resolve minimum password length constraint

### DIFF
--- a/src/main/java/com/example/authservice/dto/UserDto.java
+++ b/src/main/java/com/example/authservice/dto/UserDto.java
@@ -1,16 +1,18 @@
 package com.example.authservice.dto;
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import java.util.Objects;
 
 public final class UserDto {
+
     @NotBlank(message = "is a required field")
     @Email
     private final String username;
+
     @NotBlank(message = "is a required field")
-    @Min(value = 4, message = "must be minimum of 4 characters long")
+    @Size(min = 4, message = "must be minimum of 4 characters long")
     private final String password;
 
     public UserDto(String username, String password) {


### PR DESCRIPTION
Resolve minimum password length error caused by `@Min` constraint by replacing it with `@Size`

Closes #32 