### PR TITLE
Add Consul config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ build/
 
 ### Environmental Variables ###
 .env
+
 ### HTTP Tests ###
 Tests.http
 
+### Consul Config File ###
+**/application.yml

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,6 @@
             <version>5.6.8.Final</version>
         </dependency>
         <dependency>
-            <groupId>io.github.cdimascio</groupId>
-            <artifactId>dotenv-java</artifactId>
-            <version>2.2.3</version>
-        </dependency>
-        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
             <version>0.9.1</version>
@@ -86,11 +81,6 @@
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
             <version>0.11.5</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.cdimascio</groupId>
-            <artifactId>dotenv-java</artifactId>
-            <version>2.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/example/authservice/service/KeyService.java
+++ b/src/main/java/com/example/authservice/service/KeyService.java
@@ -13,7 +13,6 @@ import java.security.spec.PKCS8EncodedKeySpec;
 @Service
 public class KeyService {
 
-
     @Value("${key.private}")
     private String privateKey;
 

--- a/src/main/java/com/example/authservice/service/KeyService.java
+++ b/src/main/java/com/example/authservice/service/KeyService.java
@@ -1,7 +1,7 @@
 package com.example.authservice.service;
 
-import io.github.cdimascio.dotenv.Dotenv;
 import io.jsonwebtoken.io.Decoders;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.security.KeyFactory;
@@ -9,14 +9,16 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+
 @Service
 public class KeyService {
 
-    private static final Dotenv dotenv = Dotenv.configure().load();
+
+    @Value("${key.private}")
+    private String privateKey;
 
     public PrivateKey getPrivateKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
-        String key = dotenv.get("PRIVATE_KEY");
-        byte[] keyBytes = Decoders.BASE64.decode(key);
+        byte[] keyBytes = Decoders.BASE64.decode(privateKey);
         PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
         KeyFactory keyFactory = KeyFactory.getInstance("RSA");
         return keyFactory.generatePrivate(keySpec);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,10 +5,11 @@ spring.datasource.password=${DB_PASSWORD:password}
 spring.jpa.hibernate.ddl-auto=update
 server.port=${SERVER_PORT:8080}
 spring.application.name=authentication
-spring.cloud.consul.config.enabled=false
-spring.cloud.consul.discovery.register=true
-spring.cloud.consul.discovery.prefer-ip-address=true
-spring.cloud.consul.discovery.instance-id=${spring.application.name}:${spring.cloud.client.hostname}:${random.int[1,999999]}
-spring.cloud.consul.host=consul
-spring.rabbitmq.host=rabbit
-spring.rabbitmq.port=5672
+spring.cloud.consul.config.enabled=true
+#Add config service settings
+spring.config.import=optional:consul:localhost:8500
+spring.cloud.consul.config.format=yaml
+# Allow Refresh
+management.endpoint.refresh.enabled=true
+management.endpoints.web.exposure.include=refresh,health
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,6 @@
 server.error.include-message=always
-spring.datasource.url=jdbc:mysql://mysql:3306/test?allowPublicKeyRetrieval=true&useSSL=false
 spring.datasource.username=${DB_USER:user}
 spring.datasource.password=${DB_PASSWORD:password}
-spring.jpa.hibernate.ddl-auto=update
 server.port=${SERVER_PORT:8080}
 spring.application.name=authentication
 spring.cloud.consul.config.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.error.include-message=always
-spring.datasource.url=jdbc:mysql://${DB_HOST:mysql}:3306/test?allowPublicKeyRetrieval=true&useSSL=false
+spring.datasource.url=jdbc:mysql://mysql:3306/test?allowPublicKeyRetrieval=true&useSSL=false
 spring.datasource.username=${DB_USER:user}
 spring.datasource.password=${DB_PASSWORD:password}
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,11 +4,7 @@ spring.datasource.password=${DB_PASSWORD:password}
 server.port=${SERVER_PORT:8080}
 spring.application.name=authentication
 spring.cloud.consul.config.enabled=true
-
-#Add config service settings
 spring.config.import=optional:consul:consul:8500
 spring.cloud.consul.config.format=yaml
-# Allow Refresh
 management.endpoint.refresh.enabled=true
 management.endpoints.web.exposure.include=refresh,health
-

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,8 +6,9 @@ spring.jpa.hibernate.ddl-auto=update
 server.port=${SERVER_PORT:8080}
 spring.application.name=authentication
 spring.cloud.consul.config.enabled=true
+
 #Add config service settings
-spring.config.import=optional:consul:localhost:8500
+spring.config.import=optional:consul:consul:8500
 spring.cloud.consul.config.format=yaml
 # Allow Refresh
 management.endpoint.refresh.enabled=true


### PR DESCRIPTION
Included in this pull request:
- adds consul config
- removes Dotenv dependency because all "secrets" have been moved to Consul config
- updates README file 


To test this branch locally:
- create a named network according to the instructions in the README file
- start mysql, consul & rabbit containers on the network (README file)
- add configuration to Consul's UI (README file)  -  _a Private-Public key pair has been posted in our chat group_
- build a docker image from the root folder `docker build --tag test-auth:1.0 .`
- start a docker container from the local image `docker run --network <network-name> -p 8080:8080 test-auth:1.0`
- the application should be ready to test on http://localhost:8080

Closes #40 